### PR TITLE
Respond with error stanza to unknown stanzas

### DIFF
--- a/agsxmpp/Sasl/SaslHandler.cs
+++ b/agsxmpp/Sasl/SaslHandler.cs
@@ -161,7 +161,7 @@ namespace agsXMPP.Sasl
 
 					    BindIq bIq = string.IsNullOrEmpty(m_XmppClient.Resource) ? new BindIq(IqType.set) : new BindIq(IqType.set, m_XmppClient.Resource);						
 						
-                        m_XmppClient.IqGrabber.SendIq(bIq, BindResult, null);					
+                        m_XmppClient.IqGrabber.SendIq(bIq, BindResult);
 					}
 				}
 								
@@ -198,11 +198,12 @@ namespace agsXMPP.Sasl
 
             BindIq bIq = string.IsNullOrEmpty(m_XmppClient.Resource) ? new BindIq(IqType.set) : new BindIq(IqType.set, m_XmppClient.Resource);
 
-            m_XmppClient.IqGrabber.SendIq(bIq, BindResult, null);	
+            m_XmppClient.IqGrabber.SendIq(bIq, BindResult);
         }
 
-		private void BindResult(object sender, IQ iq, object data)
+		private void BindResult(object sender, IQEventArgs e)
 		{	
+            var iq = e.IQ;
 			// Once the server has generated a resource identifier for the client or accepted the resource 
 			// identifier provided by the client, it MUST return an IQ stanza of type "result" 
 			// to the client, which MUST include a <jid/> child element that specifies the full JID for 
@@ -234,7 +235,7 @@ namespace agsXMPP.Sasl
 				// success, so start the session now
 				m_XmppClient.DoChangeXmppConnectionState(XmppConnectionState.StartSession);
 				SessionIq sIq = new SessionIq(IqType.set, new Jid(m_XmppClient.Server));
-				m_XmppClient.IqGrabber.SendIq(sIq, SessionResult, null);
+				m_XmppClient.IqGrabber.SendIq(sIq, SessionResult);
 
 			}
 			else if (iq.Type == IqType.error)
@@ -244,15 +245,15 @@ namespace agsXMPP.Sasl
 			}			
 		}
 
-		private void SessionResult(object sender, IQ iq, object data)
+        private void SessionResult(object sender, IQEventArgs e)
 		{
-			if (iq.Type == IqType.result)
+            if (e.IQ.Type == IqType.result)
 			{
 				m_XmppClient.DoChangeXmppConnectionState(XmppConnectionState.SessionStarted);
 				m_XmppClient.RaiseOnLogin();
 
 			}
-			else if (iq.Type == IqType.error)
+            else if (e.IQ.Type == IqType.error)
 			{
 
 			}

--- a/agsxmpp/XmppComponentConnection.cs
+++ b/agsxmpp/XmppComponentConnection.cs
@@ -293,7 +293,7 @@ namespace agsXMPP
             else if (e is IQ)
             {
                 if (OnIq != null)
-                    OnIq(this, e as IQ);
+                    OnIq(this, new protocol.client.IQEventArgs((IQ)e));
             }
 		
 		}

--- a/agsxmpp/protocol/client/Handler.cs
+++ b/agsxmpp/protocol/client/Handler.cs
@@ -25,5 +25,19 @@ namespace agsXMPP.protocol.client
 {
     public delegate void MessageHandler (object sender, Message msg);
     public delegate void PresenceHandler(object sender, Presence pres);
-    public delegate void IqHandler      (object sender, IQ iq);
+    public delegate void IqHandler      (object sender, IQEventArgs args);
+
+    public class IQEventArgs : EventArgs
+    {
+        public IQ IQ { get; private set; }
+        public bool Handled { get; set; }
+
+        public IQEventArgs(IQ iq)
+        {
+            if (iq == null) {
+                throw new ArgumentNullException("iq");
+            }
+            IQ = iq;
+        }
+    }
 }

--- a/agsxmpp/protocol/component/Handler.cs
+++ b/agsxmpp/protocol/component/Handler.cs
@@ -25,5 +25,5 @@ namespace agsXMPP.protocol.component
 {
     public delegate void MessageHandler     (object sender, Message msg);
     public delegate void PresenceHandler    (object sender, Presence pres);
-    public delegate void IqHandler          (object sender, IQ iq);
+    public delegate void IqHandler      (object sender, client.IQEventArgs args);
 }

--- a/agsxmpp/protocol/extensions/bookmarks/BookmarkManager.cs
+++ b/agsxmpp/protocol/extensions/bookmarks/BookmarkManager.cs
@@ -40,16 +40,7 @@ namespace agsXMPP.protocol.extensions.bookmarks
         /// </summary>
         public void RequestBookmarks()
         {
-            RequestBookmarks(null, null);
-        }
-
-        /// <summary>
-        /// Request the bookmarks from the storage on the server
-        /// </summary>
-        /// <param name="cb"></param>
-        public void RequestBookmarks(IqCB cb)
-        {
-            RequestBookmarks(cb, null);
+            RequestBookmarks(null);
         }
 
         /// <summary>
@@ -57,14 +48,14 @@ namespace agsXMPP.protocol.extensions.bookmarks
         /// </summary>
         /// <param name="cb"></param>
         /// <param name="cbArgs"></param>
-        public void RequestBookmarks(IqCB cb, object cbArgs)
+        public void RequestBookmarks(IqHandler cb)
         {
             StorageIq siq = new StorageIq(IqType.get);
                       
             if (cb == null)
                 m_connection.Send(siq);
             else
-                m_connection.IqGrabber.SendIq(siq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(siq, cb);
         }
         #endregion
 
@@ -76,17 +67,7 @@ namespace agsXMPP.protocol.extensions.bookmarks
         /// <param name="urls"></param>
         public void StoreBookmarks(Url[] urls)
         {
-            StoreBookmarks(urls, null, null, null);
-        }
-
-        /// <summary>
-        /// Send booksmarks to the server storage
-        /// </summary>
-        /// <param name="urls"></param>
-        /// <param name="cb"></param>
-        public void StoreBookmarks(Url[] urls, IqCB cb)
-        {
-            StoreBookmarks(urls, null, cb, null);
+            StoreBookmarks(urls, null, null);
         }
 
         /// <summary>
@@ -95,9 +76,9 @@ namespace agsXMPP.protocol.extensions.bookmarks
         /// <param name="urls"></param>
         /// <param name="cb"></param>
         /// <param name="cbArgs"></param>
-        public void StoreBookmarks(Url[] urls, IqCB cb, object cbArgs)
+        public void StoreBookmarks(Url[] urls, IqHandler cb)
         {
-            StoreBookmarks(urls, null, cb, cbArgs);
+            StoreBookmarks(urls, null, cb);
         }
 
         /// <summary>
@@ -106,17 +87,7 @@ namespace agsXMPP.protocol.extensions.bookmarks
         /// <param name="conferences"></param>
         public void StoreBookmarks(Conference[] conferences)
         {
-            StoreBookmarks(null, conferences, null, null);
-        }
-
-        /// <summary>
-        /// Send booksmarks to the server storage
-        /// </summary>
-        /// <param name="conferences"></param>
-        /// <param name="cb"></param>
-        public void StoreBookmarks(Conference[] conferences, IqCB cb)
-        {
-            StoreBookmarks(null, conferences, cb, null);
+            StoreBookmarks(null, conferences, null);
         }
 
         /// <summary>
@@ -125,9 +96,9 @@ namespace agsXMPP.protocol.extensions.bookmarks
         /// <param name="conferences"></param>
         /// <param name="cb"></param>
         /// <param name="cbArgs"></param>
-        public void StoreBookmarks(Conference[] conferences, IqCB cb, object cbArgs)
+        public void StoreBookmarks(Conference[] conferences, IqHandler cb)
         {
-            StoreBookmarks(null, conferences, cb, cbArgs);
+            StoreBookmarks(null, conferences, cb);
         }
 
         /// <summary>
@@ -137,18 +108,7 @@ namespace agsXMPP.protocol.extensions.bookmarks
         /// <param name="conferences"></param>
         public void StoreBookmarks(Url[] urls, Conference[] conferences)
         {
-            StoreBookmarks(urls, conferences, null, null);
-        }
-
-        /// <summary>
-        /// Send booksmarks to the server storage
-        /// </summary>
-        /// <param name="urls"></param>
-        /// <param name="conferences"></param>
-        /// <param name="cb"></param>
-        public void StoreBookmarks(Url[] urls, Conference[] conferences, IqCB cb)
-        {
-            StoreBookmarks(urls, conferences, cb, null);
+            StoreBookmarks(urls, conferences, null);
         }
 
         /// <summary>
@@ -158,7 +118,7 @@ namespace agsXMPP.protocol.extensions.bookmarks
         /// <param name="conferences"></param>
         /// <param name="cb"></param>
         /// <param name="cbArgs"></param>
-        public void StoreBookmarks(Url[] urls, Conference[] conferences, IqCB cb, object cbArgs)
+        public void StoreBookmarks(Url[] urls, Conference[] conferences, IqHandler cb)
         {
             StorageIq siq = new StorageIq(IqType.set);
             
@@ -171,7 +131,7 @@ namespace agsXMPP.protocol.extensions.bookmarks
             if (cb == null)
                 m_connection.Send(siq);
             else
-                m_connection.IqGrabber.SendIq(siq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(siq, cb);
         }
         #endregion
     }

--- a/agsxmpp/protocol/extensions/pubsub/PubSubManager.cs
+++ b/agsxmpp/protocol/extensions/pubsub/PubSubManager.cs
@@ -54,25 +54,20 @@ namespace agsXMPP.protocol.extensions.pubsub
         
         public void CreateInstantNode(Jid to)
         {
-            CreateInstantNode(to, null, null, null);
+            CreateInstantNode(to, null, null);
         }
 
         public void CreateInstantNode(Jid to, Jid from)
         {
-            CreateInstantNode(to, from, null, null);
+            CreateInstantNode(to, from, null);
         }
 
-        public void CreateInstantNode(Jid to, Jid from, IqCB cb)
+        public void CreateInstantNode(Jid to, IqHandler cb)
         {
-            CreateInstantNode(to, from, cb, null);
+            CreateInstantNode(to, null, cb);
         }
 
-        public void CreateInstantNode(Jid to, IqCB cb)
-        {
-            CreateInstantNode(to, null, cb, null);
-        }
-
-        public void CreateInstantNode(Jid to, Jid from, IqCB cb,object cbArgs)
+        public void CreateInstantNode(Jid to, Jid from, IqHandler cb)
         {
             PubSubIq pubsubIq = new PubSubIq(IqType.set, to);
 
@@ -84,7 +79,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
         #endregion
 
@@ -109,12 +104,12 @@ namespace agsXMPP.protocol.extensions.pubsub
         /// <param name="node"></param>
         public void CreateNode(Jid to, string node)
         {
-            CreateNode(to, null, node, true, null, null);
+            CreateNode(to, null, node, true, null);
         }
 
         public void CreateNode(Jid to, Jid from, string node)
         {
-            CreateNode(to, from, node, true, null, null);
+            CreateNode(to, from, node, true, null);
         }
 
         /// <summary>
@@ -125,25 +120,15 @@ namespace agsXMPP.protocol.extensions.pubsub
         /// <param name="defaultConfig"></param>
         public void CreateNode(Jid to, Jid from, string node, bool defaultConfig)
         {
-            CreateNode(to, from, node, defaultConfig, null, null);
+            CreateNode(to, from, node, defaultConfig, null);
         }
 
-        public void CreateNode(Jid to, string node, bool defaultConfig, IqCB cb)
+        public void CreateNode(Jid to, string node, bool defaultConfig, IqHandler cb)
         {
-            CreateNode(to, null, node, defaultConfig, cb, null);
+            CreateNode(to, null, node, defaultConfig, cb);
         }
 
-        public void CreateNode(Jid to, string node, bool defaultConfig, IqCB cb, object cbArgs)
-        {
-            CreateNode(to, null, node, defaultConfig, cb, cbArgs);
-        }
-
-        public void CreateNode(Jid to, Jid from, string node, bool defaultConfig, IqCB cb)
-        {
-            CreateNode(to, from, node, defaultConfig, cb, null);
-        }
-
-        public void CreateNode(Jid to, Jid from, string node, bool defaultConfig, IqCB cb, object cbArgs)
+        public void CreateNode(Jid to, Jid from, string node, bool defaultConfig, IqHandler cb)
         {
             PubSubIq pubsubIq = new PubSubIq(IqType.set, to);
 
@@ -158,7 +143,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
         #endregion
 
@@ -187,31 +172,20 @@ namespace agsXMPP.protocol.extensions.pubsub
         */
         public void CreateCollectionNode(Jid to, string node, bool defaultConfig)
         {
-            CreateCollectionNode(to, null, node, defaultConfig, null, null);
+            CreateCollectionNode(to, null, node, defaultConfig, null);
         }
 
-        public void CreateCollectionNode(Jid to, string node, bool defaultConfig, IqCB cb)
+        public void CreateCollectionNode(Jid to, string node, bool defaultConfig, IqHandler cb)
         {
-            CreateCollectionNode(to, null, node, defaultConfig, cb, null);
+            CreateCollectionNode(to, null, node, defaultConfig, cb);
         }
-
-        public void CreateCollectionNode(Jid to, string node, bool defaultConfig, IqCB cb, object cbArgs)
-        {
-            CreateCollectionNode(to, null, node, defaultConfig, cb, cbArgs);
-        }
-
 
         public void CreateCollectionNode(Jid to, Jid from, string node, bool defaultConfig)
         {
-            CreateCollectionNode(to, from, node, defaultConfig, null, null);
+            CreateCollectionNode(to, from, node, defaultConfig, null);
         }
 
-        public void CreateCollectionNode(Jid to, Jid from, string node, bool defaultConfig, IqCB cb)
-        {
-            CreateCollectionNode(to, from, node, defaultConfig, cb, null);
-        }
-
-        public void CreateCollectionNode(Jid to, Jid from, string node, bool defaultConfig, IqCB cb, object cbArgs)
+        public void CreateCollectionNode(Jid to, Jid from, string node, bool defaultConfig, IqHandler cb)
         {
             PubSubIq pubsubIq = new PubSubIq(IqType.set, to);
 
@@ -226,7 +200,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
         #endregion
 
@@ -246,30 +220,20 @@ namespace agsXMPP.protocol.extensions.pubsub
 
         public void DeleteNode(Jid to, string node)
         {
-            DeleteNode(to, null, node, null, null);
+            DeleteNode(to, null, node, null);
         }
 
-        public void DeleteNode(Jid to, string node, IqCB cb)
+        public void DeleteNode(Jid to, string node, IqHandler cb)
         {
-            DeleteNode(to, null, node, cb, null);
-        }
-        
-        public void DeleteNode(Jid to, string node, IqCB cb, object cbArgs)
-        {
-            DeleteNode(to, null, node, cb, cbArgs);
+            DeleteNode(to, null, node, cb);
         }
 
         public void DeleteNode(Jid to, Jid from, string node)
         {
-            DeleteNode(to, from, node, null, null);
+            DeleteNode(to, from, node, null);
         }
 
-        public void DeleteNode(Jid to, Jid from, string node, IqCB cb)
-        {
-            DeleteNode(to, from, node, cb, null);
-        }
-
-        public void DeleteNode(Jid to, Jid from, string node, IqCB cb, object cbArgs)
+        public void DeleteNode(Jid to, Jid from, string node, IqHandler cb)
         {
             owner.PubSubIq pubsubIq = new owner.PubSubIq(IqType.set, to);
 
@@ -281,7 +245,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
         #endregion
 
@@ -301,30 +265,20 @@ namespace agsXMPP.protocol.extensions.pubsub
 
         public void PurgeNode(Jid to, string node)
         {
-            PurgeNode(to, null, node, null, null);
+            PurgeNode(to, null, node, null);
         }
 
-        public void PurgeNode(Jid to, string node, IqCB cb)
+        public void PurgeNode(Jid to, string node, IqHandler cb)
         {
-            PurgeNode(to, null, node, cb, null);
-        }
-
-        public void PurgeNode(Jid to, string node, IqCB cb, object cbArgs)
-        {
-            PurgeNode(to, null, node, cb, cbArgs);
+            PurgeNode(to, null, node, cb);
         }
 
         public void PurgeNode(Jid to, Jid from, string node)
         {
-            PurgeNode(to, from, node, null, null);
+            PurgeNode(to, from, node, null);
         }
 
-        public void PurgeNode(Jid to, Jid from, string node, IqCB cb)
-        {
-            PurgeNode(to, from, node, cb, null);
-        }
-
-        public void PurgeNode(Jid to, Jid from, string node, IqCB cb, object cbArgs)
+        public void PurgeNode(Jid to, Jid from, string node, IqHandler cb)
         {
             owner.PubSubIq pubsubIq = new owner.PubSubIq(IqType.set, to);
 
@@ -336,7 +290,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
         #endregion
 
@@ -370,7 +324,7 @@ namespace agsXMPP.protocol.extensions.pubsub
         /// <param name="payload"></param>
         public void PublishItem(Jid to, string node, Item payload)
         {
-            PublishItem(to, null, node, payload, null, null);
+            PublishItem(to, null, node, payload, null);
         }
 
         /// <summary>
@@ -380,22 +334,9 @@ namespace agsXMPP.protocol.extensions.pubsub
         /// <param name="node"></param>
         /// <param name="payload"></param>
         /// <param name="cb"></param>
-        public void PublishItem(Jid to, string node, Item payload, IqCB cb)
+        public void PublishItem(Jid to, string node, Item payload, IqHandler cb)
         {
-            PublishItem(to, null, node, payload, cb, null);
-        }
-
-        /// <summary>
-        /// Publish a payload to a Node
-        /// </summary>
-        /// <param name="to"></param>
-        /// <param name="node"></param>
-        /// <param name="payload"></param>
-        /// <param name="cb"></param>
-        /// <param name="cbArgs"></param>
-        public void PublishItem(Jid to, string node, Item payload, IqCB cb, object cbArgs)
-        {
-            PublishItem(to, null, node, payload, cb, cbArgs);
+            PublishItem(to, null, node, payload, cb);
         }
 
         /// <summary>
@@ -407,7 +348,7 @@ namespace agsXMPP.protocol.extensions.pubsub
         /// <param name="payload"></param>
         public void PublishItem(Jid to, Jid from, string node, Item payload)
         {
-            PublishItem(to, from, node, payload, null, null);
+            PublishItem(to, from, node, payload, null);
         }
 
         /// <summary>
@@ -418,21 +359,7 @@ namespace agsXMPP.protocol.extensions.pubsub
         /// <param name="node"></param>
         /// <param name="payload"></param>
         /// <param name="cb"></param>
-        public void PublishItem(Jid to, Jid from, string node, Item payload, IqCB cb)
-        {
-            PublishItem(to, from, node, payload, cb, null);
-        }
-
-        /// <summary>
-        /// Publish a payload to a Node
-        /// </summary>
-        /// <param name="to"></param>
-        /// <param name="from"></param>
-        /// <param name="node"></param>
-        /// <param name="payload"></param>
-        /// <param name="cb"></param>
-        /// <param name="cbArgs"></param>
-        public void PublishItem(Jid to, Jid from, string node, Item payload, IqCB cb, object cbArgs)
+        public void PublishItem(Jid to, Jid from, string node, Item payload, IqHandler cb)
         {
             PubSubIq pubsubIq = new PubSubIq(IqType.set, to);
 
@@ -447,7 +374,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
 
         #endregion
@@ -468,31 +395,21 @@ namespace agsXMPP.protocol.extensions.pubsub
 
         public void RetractItem(Jid to, string node, string id)
         {
-            RetractItem(to, null, node, id, null, null);
+            RetractItem(to, null, node, id, null);
         }
 
-        public void RetractItem(Jid to, string node, string id, IqCB cb)
+        public void RetractItem(Jid to, string node, string id, IqHandler cb)
         {
-            RetractItem(to, null, node, id, cb, null);
-        }
-
-        public void RetractItem(Jid to, string node, string id, IqCB cb, object cbArgs)
-        {
-            RetractItem(to, null, node, id, cb, cbArgs);
+            RetractItem(to, null, node, id, cb);
         }
 
 
         public void RetractItem(Jid to, Jid from, string node, string id)
         {
-            RetractItem(to, from, node, id, null, null);
+            RetractItem(to, from, node, id, null);
         }
 
-        public void RetractItem(Jid to, Jid from, string node, string id, IqCB cb)
-        {
-            RetractItem(to, from, node, id, cb, null);
-        }
-
-        public void RetractItem(Jid to, Jid from, string node, string id, IqCB cb, object cbArgs)
+        public void RetractItem(Jid to, Jid from, string node, string id, IqHandler cb)
         {
             PubSubIq pubsubIq = new PubSubIq(IqType.set, to);
 
@@ -505,7 +422,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
         #endregion
 
@@ -531,30 +448,20 @@ namespace agsXMPP.protocol.extensions.pubsub
         /// <param name="node">node to which we want to subscribe</param>
         public void Subscribe(Jid to, Jid subscribe, string node)
         {
-            Subscribe(to, null, subscribe, node, null, null);
+            Subscribe(to, null, subscribe, node, null);
         }
 
-        public void Subscribe(Jid to, Jid subscribe, string node, IqCB cb)
+        public void Subscribe(Jid to, Jid subscribe, string node, IqHandler cb)
         {
-            Subscribe(to, null, subscribe, node, cb, null);
-        }
-
-        public void Subscribe(Jid to, Jid subscribe, string node, IqCB cb, object cbArgs)
-        {
-            Subscribe(to, null, subscribe, node, cb, cbArgs);
+            Subscribe(to, null, subscribe, node, cb);
         }
 
         public void Subscribe(Jid to, Jid from, Jid subscribe, string node)
         {
-            Subscribe(to, from, subscribe, node, null, null);
+            Subscribe(to, from, subscribe, node, null);
         }
 
-        public void Subscribe(Jid to, Jid from, Jid subscribe, string node, IqCB cb)
-        {
-            Subscribe(to, from, subscribe, node, cb, null);
-        }
-
-        public void Subscribe(Jid to, Jid from, Jid subscribe, string node, IqCB cb, object cbArgs)
+        public void Subscribe(Jid to, Jid from, Jid subscribe, string node, IqHandler cb)
         {
             PubSubIq pubsubIq = new PubSubIq(IqType.set, to);
 
@@ -566,7 +473,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
 
         #endregion
@@ -601,27 +508,17 @@ namespace agsXMPP.protocol.extensions.pubsub
 
         public void Unsubscribe(Jid to, Jid unsubscribe, string node, string subid)
         {
-            Unsubscribe(to, null, unsubscribe, node, subid, null, null);
+            Unsubscribe(to, null, unsubscribe, node, subid, null);
         }
 
-        public void Unsubscribe(Jid to, Jid unsubscribe, string node, IqCB cb)
+        public void Unsubscribe(Jid to, Jid unsubscribe, string node, IqHandler cb)
         {
-            Unsubscribe(to, null, unsubscribe, node, cb, null);
+            Unsubscribe(to, null, unsubscribe, node, cb);
         }
 
-        public void Unsubscribe(Jid to, Jid unsubscribe, string node, string subid, IqCB cb)
+        public void Unsubscribe(Jid to, Jid unsubscribe, string node, string subid, IqHandler cb)
         {
-            Unsubscribe(to, null, unsubscribe, node, subid, cb, null);
-        }
-
-        public void Unsubscribe(Jid to, Jid unsubscribe, string node, IqCB cb, object cbArgs)
-        {
-            Unsubscribe(to, null, unsubscribe, node, cb, cbArgs);
-        }
-
-        public void Unsubscribe(Jid to, Jid unsubscribe, string node, string subid, IqCB cb, object cbArgs)
-        {
-            Unsubscribe(to, null, unsubscribe, node, subid, cb, cbArgs);
+            Unsubscribe(to, null, unsubscribe, node, subid, cb);
         }
 
         public void Unsubscribe(Jid to, Jid from, Jid unsubscribe, string node)
@@ -631,25 +528,15 @@ namespace agsXMPP.protocol.extensions.pubsub
 
         public void Unsubscribe(Jid to, Jid from, Jid unsubscribe, string node, string subid)
         {
-            Unsubscribe(to, from, unsubscribe, node, subid, null, null);
+            Unsubscribe(to, from, unsubscribe, node, subid, null);
         }
 
-        public void Unsubscribe(Jid to, Jid from, Jid unsubscribe, string node, IqCB cb)
+        public void Unsubscribe(Jid to, Jid from, Jid unsubscribe, string node, IqHandler cb)
         {
-            Unsubscribe(to, from, unsubscribe, node, cb, null);
+            Unsubscribe(to, from, unsubscribe, node, cb);
         }
 
-        public void Unsubscribe(Jid to, Jid from, Jid unsubscribe, string node, string subid, IqCB cb)
-        {
-            Unsubscribe(to, from, unsubscribe, node, subid, cb, null);
-        }
-
-        public void Unsubscribe(Jid to, Jid from, Jid unsubscribe, string node, IqCB cb, object cbArgs)
-        {
-            Unsubscribe(to, from, unsubscribe, node, null, cb, cbArgs);
-        }
-
-        public void Unsubscribe(Jid to, Jid from, Jid unsubscribe, string node, string subid, IqCB cb, object cbArgs)
+        public void Unsubscribe(Jid to, Jid from, Jid unsubscribe, string node, string subid, IqHandler cb)
         {
             PubSubIq pubsubIq = new PubSubIq(IqType.set, to);
 
@@ -665,7 +552,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
 
         #endregion
@@ -683,30 +570,20 @@ namespace agsXMPP.protocol.extensions.pubsub
         */
         public void RequestSubscriptions(Jid to)
         {
-            RequestSubscriptions(to, null, null, null);
+            RequestSubscriptions(to, null, null);
         }
 
-        public void RequestSubscriptions(Jid to, IqCB cb)
+        public void RequestSubscriptions(Jid to, IqHandler cb)
         {
-            RequestSubscriptions(to, null, cb, null);
-        }
-
-        public void RequestSubscriptions(Jid to, IqCB cb, object cbArgs)
-        {
-            RequestSubscriptions(to, null, cb, cbArgs);
+            RequestSubscriptions(to, null, cb);
         }
 
         public void RequestSubscriptions(Jid to, Jid from)
         {
-            RequestSubscriptions(to, from, null, null);
+            RequestSubscriptions(to, from, null);
         }
 
-        public void RequestSubscriptions(Jid to, Jid from, IqCB cb)
-        {
-            RequestSubscriptions(to, from, cb, null);
-        }
-
-        public void RequestSubscriptions(Jid to, Jid from, IqCB cb, object cbArgs)
+        public void RequestSubscriptions(Jid to, Jid from, IqHandler cb)
         {
             PubSubIq pubsubIq = new PubSubIq(IqType.get, to);
 
@@ -718,7 +595,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
         #endregion
 
@@ -735,30 +612,20 @@ namespace agsXMPP.protocol.extensions.pubsub
         */
         public void RequestAffiliations(Jid to)
         {
-            RequestAffiliations(to, null, null, null);
+            RequestAffiliations(to, null, null);
         }
 
-        public void RequestAffiliations(Jid to, IqCB cb)
+        public void RequestAffiliations(Jid to, IqHandler cb)
         {
-            RequestAffiliations(to, null, cb, null);
-        }
-
-        public void RequestAffiliations(Jid to, IqCB cb, object cbArgs)
-        {
-            RequestAffiliations(to, null, cb, cbArgs);
+            RequestAffiliations(to, null, cb);
         }
 
         public void RequestAffiliations(Jid to, Jid from)
         {
-            RequestAffiliations(to, from, null, null);
+            RequestAffiliations(to, from, null);
         }
 
-        public void RequestAffiliations(Jid to, Jid from, IqCB cb)
-        {
-            RequestAffiliations(to, from, cb, null);
-        }
-
-        public void RequestAffiliations(Jid to, Jid from, IqCB cb, object cbArgs)
+        public void RequestAffiliations(Jid to, Jid from, IqHandler cb)
         {
             PubSubIq pubsubIq = new PubSubIq(IqType.get, to);
 
@@ -770,7 +637,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
         #endregion
 
@@ -788,30 +655,20 @@ namespace agsXMPP.protocol.extensions.pubsub
 
         public void RequestSubscriptionOptions(Jid to, Jid subscribe, string node)
         {
-            RequestSubscriptionOptions(to, null, subscribe, node, null, null);
+            RequestSubscriptionOptions(to, null, subscribe, node, null);
         }
 
-        public void RequestSubscriptionOptions(Jid to, Jid subscribe, string node, IqCB cb)
+        public void RequestSubscriptionOptions(Jid to, Jid subscribe, string node, IqHandler cb)
         {
-            RequestSubscriptionOptions(to, null, subscribe, node, cb, null);
-        }
-
-        public void RequestSubscriptionOptions(Jid to, Jid subscribe, string node, IqCB cb, object cbArgs)
-        {
-            RequestSubscriptionOptions(to, null, subscribe, node, cb, cbArgs);
+            RequestSubscriptionOptions(to, null, subscribe, node, cb);
         }
 
         public void RequestSubscriptionOptions(Jid to, Jid from, Jid subscribe, string node)
         {
-            RequestSubscriptionOptions(to, from, subscribe, node, null, null);
+            RequestSubscriptionOptions(to, from, subscribe, node, null);
         }
 
-        public void RequestSubscriptionOptions(Jid to, Jid from, Jid subscribe, string node, IqCB cb)
-        {
-            RequestSubscriptionOptions(to, from, subscribe, node, cb, null);
-        }
-
-        public void RequestSubscriptionOptions(Jid to, Jid from, Jid subscribe, string node, IqCB cb, object cbArgs)
+        public void RequestSubscriptionOptions(Jid to, Jid from, Jid subscribe, string node, IqHandler cb)
         {
             PubSubIq pubsubIq = new PubSubIq(IqType.get, to);
 
@@ -823,7 +680,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
         #endregion
 
@@ -841,30 +698,20 @@ namespace agsXMPP.protocol.extensions.pubsub
 
         public void OwnerRequestSubscribers(Jid to, string node)
         {
-            OwnerRequestSubscribers(to, null, node, null, null);
+            OwnerRequestSubscribers(to, null, node, null);
         }
 
-        public void OwnerRequestSubscribers(Jid to, string node, IqCB cb)
+        public void OwnerRequestSubscribers(Jid to, string node, IqHandler cb)
         {
-            OwnerRequestSubscribers(to, null, node, cb, null);
-        }
-
-        public void OwnerRequestSubscribers(Jid to, string node, IqCB cb, object cbArgs)
-        {
-            OwnerRequestSubscribers(to, null, node, cb, cbArgs);
+            OwnerRequestSubscribers(to, null, node, cb);
         }
 
         public void OwnerRequestSubscribers(Jid to, Jid from, string node)
         {
-            OwnerRequestSubscribers(to, from, node, null, null);
+            OwnerRequestSubscribers(to, from, node, null);
         }
 
-        public void OwnerRequestSubscribers(Jid to, Jid from, string node, IqCB cb)
-        {
-            OwnerRequestSubscribers(to, from, node, cb, null);
-        }
-
-        public void OwnerRequestSubscribers(Jid to, Jid from, string node, IqCB cb, object cbArgs)
+        public void OwnerRequestSubscribers(Jid to, Jid from, string node, IqHandler cb)
         {
             owner.PubSubIq pubsubIq = new owner.PubSubIq(IqType.get, to);
 
@@ -876,7 +723,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
         #endregion
 
@@ -904,31 +751,20 @@ namespace agsXMPP.protocol.extensions.pubsub
 
         public void OwnerModifySubscriptionState(Jid to, string node, Jid subscriber, SubscriptionState state)
         {
-            OwnerModifySubscriptionState(to, null, node, subscriber, state, null, null);
+            OwnerModifySubscriptionState(to, null, node, subscriber, state, null);
         }
 
-        public void OwnerModifySubscriptionState(Jid to, string node, Jid subscriber, SubscriptionState state, IqCB cb)
+        public void OwnerModifySubscriptionState(Jid to, string node, Jid subscriber, SubscriptionState state, IqHandler cb)
         {
-            OwnerModifySubscriptionState(to, null, node, subscriber, state, cb, null);
+            OwnerModifySubscriptionState(to, null, node, subscriber, state, cb);
         }
-
-        public void OwnerModifySubscriptionState(Jid to, string node, Jid subscriber, SubscriptionState state, IqCB cb, object cbArgs)
-        {
-            OwnerModifySubscriptionState(to, null, node, subscriber, state, cb, cbArgs);
-        }
-
 
         public void OwnerModifySubscriptionState(Jid to, Jid from, string node, Jid subscriber, SubscriptionState state)
         {
-            OwnerModifySubscriptionState(to, from, node, subscriber, state, null, null);
+            OwnerModifySubscriptionState(to, from, node, subscriber, state, null);
         }
 
-        public void OwnerModifySubscriptionState(Jid to, Jid from, string node, Jid subscriber, SubscriptionState state, IqCB cb)
-        {
-            OwnerModifySubscriptionState(to, from, node, subscriber, state, cb, null);
-        }
-
-        public void OwnerModifySubscriptionState(Jid to, Jid from, string node, Jid subscriber, SubscriptionState state, IqCB cb, object cbArgs)
+        public void OwnerModifySubscriptionState(Jid to, Jid from, string node, Jid subscriber, SubscriptionState state, IqHandler cb)
         {
             owner.PubSubIq pubsubIq = new owner.PubSubIq(IqType.set, to);
 
@@ -943,7 +779,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
         #endregion
 
@@ -964,31 +800,20 @@ namespace agsXMPP.protocol.extensions.pubsub
 
         public void OwnerModifySubscriptionStates(Jid to, string node, owner.Subscriber[] subscribers)
         {
-            OwnerModifySubscriptionStates(to, null, node, subscribers, null, null);
+            OwnerModifySubscriptionStates(to, null, node, subscribers, null);
         }
 
-        public void OwnerModifySubscriptionStates(Jid to, string node, owner.Subscriber[] subscribers, IqCB cb)
+        public void OwnerModifySubscriptionStates(Jid to, string node, owner.Subscriber[] subscribers, IqHandler cb)
         {
-            OwnerModifySubscriptionStates(to, null, node, subscribers, cb, null);
+            OwnerModifySubscriptionStates(to, null, node, subscribers, cb);
         }
-
-        public void OwnerModifySubscriptionStates(Jid to, string node, owner.Subscriber[] subscribers, IqCB cb, object cbArgs)
-        {
-            OwnerModifySubscriptionStates(to, null, node, subscribers, cb, cbArgs);
-        }
-
 
         public void OwnerModifySubscriptionStates(Jid to, Jid from, string node, owner.Subscriber[] subscribers)
         {
-            OwnerModifySubscriptionStates(to, from, node, subscribers, null, null);
+            OwnerModifySubscriptionStates(to, from, node, subscribers, null);
         }
 
-        public void OwnerModifySubscriptionStates(Jid to, Jid from, string node, owner.Subscriber[] subscribers, IqCB cb)
-        {
-            OwnerModifySubscriptionStates(to, from, node, subscribers, cb, null);
-        }
-
-        public void OwnerModifySubscriptionStates(Jid to, Jid from, string node, owner.Subscriber[] subscribers, IqCB cb, object cbArgs)
+        public void OwnerModifySubscriptionStates(Jid to, Jid from, string node, owner.Subscriber[] subscribers, IqHandler cb)
         {
             owner.PubSubIq pubsubIq = new owner.PubSubIq(IqType.set, to);
 
@@ -1003,7 +828,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
         #endregion
 
@@ -1023,31 +848,20 @@ namespace agsXMPP.protocol.extensions.pubsub
 
         public void OwnerRequestAffiliations(Jid to, string node)
         {
-            OwnerRequestAffiliations(to, null, node, null, null);
+            OwnerRequestAffiliations(to, null, node, null);
         }
 
-        public void OwnerRequestAffiliations(Jid to, string node, IqCB cb)
+        public void OwnerRequestAffiliations(Jid to, string node, IqHandler cb)
         {
-            OwnerRequestAffiliations(to, null, node, cb, null);
+            OwnerRequestAffiliations(to, null, node, cb);
         }
-
-        public void OwnerRequestAffiliations(Jid to, string node, IqCB cb, object cbArgs)
-        {
-            OwnerRequestAffiliations(to, null, node, cb, cbArgs);
-        }
-
 
         public void OwnerRequestAffiliations(Jid to, Jid from, string node)
         {
-            OwnerRequestAffiliations(to, from, node, null, null);
+            OwnerRequestAffiliations(to, from, node, null);
         }
 
-        public void OwnerRequestAffiliations(Jid to, Jid from, string node, IqCB cb)
-        {
-            OwnerRequestAffiliations(to, from, node, cb, null);
-        }
-
-        public void OwnerRequestAffiliations(Jid to, Jid from, string node, IqCB cb, object cbArgs)
+        public void OwnerRequestAffiliations(Jid to, Jid from, string node, IqHandler cb)
         {
             owner.PubSubIq pubsubIq = new owner.PubSubIq(IqType.get, to);
 
@@ -1059,7 +873,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
         #endregion
 
@@ -1082,31 +896,20 @@ namespace agsXMPP.protocol.extensions.pubsub
         
         public void OwnerModifyAffiliation(Jid to, string node, Jid affiliate, AffiliationType affiliation)
         {
-            OwnerModifyAffiliation(to, null, node, affiliate, affiliation, null, null);
+            OwnerModifyAffiliation(to, null, node, affiliate, affiliation, null);
         }
         
-        public void OwnerModifyAffiliation(Jid to, string node, Jid affiliate, AffiliationType affiliation, IqCB cb)
+        public void OwnerModifyAffiliation(Jid to, string node, Jid affiliate, AffiliationType affiliation, IqHandler cb)
         {
-            OwnerModifyAffiliation(to, null, node, affiliate, affiliation, cb, null);
+            OwnerModifyAffiliation(to, null, node, affiliate, affiliation, cb);
         }
-
-        public void OwnerModifyAffiliation(Jid to, string node, Jid affiliate, AffiliationType affiliation, IqCB cb, object cbArgs)
-        {
-            OwnerModifyAffiliation(to, null, node, affiliate, affiliation, cb, cbArgs);
-        }
-
 
         public void OwnerModifyAffiliation(Jid to, Jid from, string node, Jid affiliate, AffiliationType affiliation)
         {
-            OwnerModifyAffiliation(to, from, node, affiliate, affiliation, null, null);
+            OwnerModifyAffiliation(to, from, node, affiliate, affiliation, null);
         }
-        
-        public void OwnerModifyAffiliation(Jid to, Jid from, string node, Jid affiliate, AffiliationType affiliation, IqCB cb)
-        {
-            OwnerModifyAffiliation(to, from, node, affiliate, affiliation, cb, null);
-        }
-        
-        public void OwnerModifyAffiliation(Jid to, Jid from, string node, Jid affiliate, AffiliationType affiliation, IqCB cb, object cbArgs)
+
+        public void OwnerModifyAffiliation(Jid to, Jid from, string node, Jid affiliate, AffiliationType affiliation, IqHandler cb)
         {
             owner.PubSubIq pubsubIq = new owner.PubSubIq(IqType.set, to);
 
@@ -1121,7 +924,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
         #endregion
 
@@ -1145,31 +948,20 @@ namespace agsXMPP.protocol.extensions.pubsub
 
         public void OwnerModifyAffiliations(Jid to, string node, owner.Affiliate[] affiliates)
         {
-            OwnerModifyAffiliations(to, null, node, affiliates, null, null);
+            OwnerModifyAffiliations(to, null, node, affiliates, null);
         }
 
-        public void OwnerModifyAffiliations(Jid to, string node, owner.Affiliate[] affiliates, IqCB cb)
+        public void OwnerModifyAffiliations(Jid to, string node, owner.Affiliate[] affiliates, IqHandler cb)
         {
-            OwnerModifyAffiliations(to, null, node, affiliates, cb, null);
+            OwnerModifyAffiliations(to, null, node, affiliates, cb);
         }
-
-        public void OwnerModifyAffiliations(Jid to, string node, owner.Affiliate[] affiliates, IqCB cb, object cbArgs)
-        {
-            OwnerModifyAffiliations(to, null, node, affiliates, cb, cbArgs);
-        }
-
 
         public void OwnerModifyAffiliations(Jid to, Jid from, string node, owner.Affiliate[] affiliates)
         {
-            OwnerModifyAffiliations(to, from, node, affiliates, null, null);
+            OwnerModifyAffiliations(to, from, node, affiliates, null);
         }
 
-        public void OwnerModifyAffiliations(Jid to, Jid from, string node, owner.Affiliate[] affiliates, IqCB cb)
-        {
-            OwnerModifyAffiliations(to, from, node, affiliates, cb, null);
-        }
-
-        public void OwnerModifyAffiliations(Jid to, Jid from, string node, owner.Affiliate[] affiliates, IqCB cb, object cbArgs)
+        public void OwnerModifyAffiliations(Jid to, Jid from, string node, owner.Affiliate[] affiliates, IqHandler cb)
         {
             owner.PubSubIq pubsubIq = new owner.PubSubIq(IqType.set, to);
 
@@ -1184,7 +976,7 @@ namespace agsXMPP.protocol.extensions.pubsub
             if (cb == null)
                 m_connection.Send(pubsubIq);
             else
-                m_connection.IqGrabber.SendIq(pubsubIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(pubsubIq, cb);
         }
         #endregion
     }

--- a/agsxmpp/protocol/iq/disco/DiscoManager.cs
+++ b/agsxmpp/protocol/iq/disco/DiscoManager.cs
@@ -54,11 +54,13 @@ namespace agsXMPP.protocol.iq.disco
         }
         #endregion
 
-        private void OnIq(object sender, IQ iq)
+        private void OnIq(object sender, IQEventArgs e)
         {
             // DiscoInfo
-            if (m_AutoAnswerDiscoInfoRequests && iq.Query is DiscoInfo && iq.Type == IqType.get)
-                ProcessDiscoInfo(iq);
+            if (m_AutoAnswerDiscoInfoRequests && e.IQ.Query is DiscoInfo && e.IQ.Type == IqType.get) {
+                e.Handled = true;
+                ProcessDiscoInfo(e.IQ);
+            }
         }
 
         private void ProcessDiscoInfo(IQ iq)
@@ -76,59 +78,40 @@ namespace agsXMPP.protocol.iq.disco
         #region << Discover Info >>
         public void DiscoverInformation(Jid to)
         {
-            DiscoverInformation(to, null, null, null, null);
+            DiscoverInformation(to, null, null, null);
         }
 
         public void DiscoverInformation(Jid to, Jid from)
         {
-            DiscoverInformation(to, from, null, null, null);
+            DiscoverInformation(to, from, null, null);
         }
 
-        public void DiscoverInformation(Jid to, IqCB cb)
+        public void DiscoverInformation(Jid to, IqHandler cb)
         {
-            DiscoverInformation(to, null, null, cb, null);
+            DiscoverInformation(to, null, null, cb);
         }
 
-        public void DiscoverInformation(Jid to, Jid from, IqCB cb)
+        public void DiscoverInformation(Jid to, Jid from, IqHandler cb)
         {
-            DiscoverInformation(to, from, null, cb, null);
-        }
-
-        public void DiscoverInformation(Jid to, IqCB cb, object cbArgs)
-        {
-            DiscoverInformation(to, null, null, cb, cbArgs);
-        }
-
-        public void DiscoverInformation(Jid to, Jid from, IqCB cb, object cbArgs)
-        {
-            DiscoverInformation(to, from, null, cb, cbArgs);
+            DiscoverInformation(to, from, null, cb);
         }
 
         public void DiscoverInformation(Jid to, string node)
         {
-            DiscoverInformation(to, null, node, null, null);
+            DiscoverInformation(to, null, node, null);
         }
 
         public void DiscoverInformation(Jid to, Jid from, string node)
         {
-            DiscoverInformation(to, from, node, null, null);
+            DiscoverInformation(to, from, node, null);
         }
 
-        public void DiscoverInformation(Jid to, string node, IqCB cb)
+        public void DiscoverInformation(Jid to, string node, IqHandler cb)
         {
-            DiscoverInformation(to, null, node, cb, null);
+            DiscoverInformation(to, null, node, cb);
         }
 
-        public void DiscoverInformation(Jid to, Jid from, string node, IqCB cb)
-        {
-            DiscoverInformation(to, from, node, cb, null);
-        }
-
-        public void DiscoverInformation(Jid to, string node, IqCB cb, object cbArgs)
-        {
-            DiscoverInformation(to, null, node, cb, cbArgs);
-        }
-        public void DiscoverInformation(Jid to, Jid from, string node, IqCB cb, object cbArgs)
+        public void DiscoverInformation(Jid to, Jid from, string node, IqHandler cb)
         {
             /*
             
@@ -166,7 +149,7 @@ namespace agsXMPP.protocol.iq.disco
             if (node != null && node.Length > 0)
                 discoIq.Query.Node = node;
             
-            xmppConnection.IqGrabber.SendIq(discoIq, cb, cbArgs);
+            xmppConnection.IqGrabber.SendIq(discoIq, cb);
         }
         #endregion
 
@@ -178,55 +161,35 @@ namespace agsXMPP.protocol.iq.disco
 
         public void DiscoverItems(Jid to, Jid from)
         {
-            DiscoverItems(to, from, null, null, null);
+            DiscoverItems(to, from, null, null);
         }
 
-        public void DiscoverItems(Jid to, IqCB cb)
+        public void DiscoverItems(Jid to, IqHandler cb)
         {
-            DiscoverItems(to, null, null, cb, null);
+            DiscoverItems(to, null, null, cb);
         }
 
-        public void DiscoverItems(Jid to, Jid from, IqCB cb)
+        public void DiscoverItems(Jid to, Jid from, IqHandler cb)
         {
-            DiscoverItems(to, from, null, cb, null);
-        }
-
-        public void DiscoverItems(Jid to, IqCB cb, object cbArgs)
-        {
-            DiscoverItems(to, null, null, cb, cbArgs);
-        }
-
-        public void DiscoverItems(Jid to, Jid from, IqCB cb, object cbArgs)
-        {
-            DiscoverItems(to, from, null, cb, cbArgs);
+            DiscoverItems(to, from, null, cb);
         }
 
         public void DiscoverItems(Jid to, string node)
         {
-            DiscoverItems(to, null, node, null, null);
+            DiscoverItems(to, null, node, null);
         }
 
         public void DiscoverItems(Jid to, Jid from, string node)
         {
-            DiscoverItems(to, from, node, null, null);
+            DiscoverItems(to, from, node, null);
         }
 
-        public void DiscoverItems(Jid to, string node, IqCB cb)
+        public void DiscoverItems(Jid to, string node, IqHandler cb)
         {
-            DiscoverItems(to, null, node, cb, null);
+            DiscoverItems(to, null, node, cb);
         }
 
-        public void DiscoverItems(Jid to, Jid from, string node, IqCB cb)
-        {
-            DiscoverItems(to, from, node, cb, null);
-        }
-
-        public void DiscoverItems(Jid to, string node, IqCB cb, object cbArgs)
-        {
-            DiscoverItems(to, null, node, cb, cbArgs);
-        }
-
-        public void DiscoverItems(Jid to, Jid from, string node, IqCB cb, object cbArgs)
+        public void DiscoverItems(Jid to, Jid from, string node, IqHandler cb)
         {
             DiscoItemsIq discoIq = new DiscoItemsIq(IqType.get);
             discoIq.To = to;
@@ -237,7 +200,7 @@ namespace agsXMPP.protocol.iq.disco
             if (node != null && node.Length > 0)
                 discoIq.Query.Node = node;
 
-            xmppConnection.IqGrabber.SendIq(discoIq, cb, cbArgs);
+            xmppConnection.IqGrabber.SendIq(discoIq, cb);
         }
         #endregion
                         

--- a/agsxmpp/protocol/iq/privacy/PrivacyManager.cs
+++ b/agsxmpp/protocol/iq/privacy/PrivacyManager.cs
@@ -45,7 +45,7 @@ namespace agsXMPP.protocol.iq.privacy
         /// </summary>
         public void GetLists()
         {
-            GetLists(null, null);
+            GetLists(null);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace agsXMPP.protocol.iq.privacy
         /// </summary>
         /// <param name="cb">Callback for the server result</param>
         /// <param name="cbArg">Callback arguments for the result when needed</param>
-        public void GetLists(IqCB cb, object cbArg)
+        public void GetLists(IqHandler cb)
         {
             /*
                 Example: Client requests names of privacy lists from server:
@@ -80,7 +80,7 @@ namespace agsXMPP.protocol.iq.privacy
 
             pIq.Type = agsXMPP.protocol.client.IqType.get;
 
-            SendStanza(pIq, cb, cbArg);
+            SendStanza(pIq, cb);
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace agsXMPP.protocol.iq.privacy
         /// <param name="name">name of the privacy list to retrieve</param>
         public void GetList(string name)
         {
-            GetList(name, null, null);
+            GetList(name, null);
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace agsXMPP.protocol.iq.privacy
         /// <param name="name">name of the privacy list to retrieve</param>
         /// <param name="cb">Callback for the server result</param>
         /// <param name="cbArg">Callback arguments for the result when needed</param>
-        public void GetList(string name, IqCB cb, object cbArg)
+        public void GetList(string name, IqHandler cb)
         {
             /*
                 Example: Client requests a privacy list from server:
@@ -130,7 +130,7 @@ namespace agsXMPP.protocol.iq.privacy
             pIq.Type = agsXMPP.protocol.client.IqType.get;
             pIq.Query.AddList(new List(name));
 
-            SendStanza(pIq, cb, cbArg);            
+            SendStanza(pIq, cb);            
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace agsXMPP.protocol.iq.privacy
         /// <param name="name">name of the privacy list to remove</param>
         public void RemoveList(string name)
         {
-            RemoveList(name, null, null);
+            RemoveList(name, null);
         }
 
         /// <summary>
@@ -148,14 +148,14 @@ namespace agsXMPP.protocol.iq.privacy
         /// <param name="name">name of the privacy list to remove</param>
         /// <param name="cb">Callback for the server result</param>
         /// <param name="cbArg">Callback arguments for the result when needed</param>
-        public void RemoveList(string name, IqCB cb, object cbArg)
+        public void RemoveList(string name, IqHandler cb)
         {
             PrivacyIq pIq = new PrivacyIq();
 
             pIq.Type = agsXMPP.protocol.client.IqType.set;
             pIq.Query.AddList(new List(name));
 
-            SendStanza(pIq, cb, cbArg);            
+            SendStanza(pIq, cb);            
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace agsXMPP.protocol.iq.privacy
         /// </summary>
         public void DeclineActiveList()
         {
-            DeclineActiveList(null, null);
+            DeclineActiveList(null);
         }
 
         /// <summary>
@@ -171,7 +171,7 @@ namespace agsXMPP.protocol.iq.privacy
         /// </summary>
         /// <param name="cb">Callback for the server result</param>
         /// <param name="cbArg">Callback arguments for the result when needed</param>
-        public void DeclineActiveList(IqCB cb, object cbArg)
+        public void DeclineActiveList(IqHandler cb)
         {
             /*
                 In order to decline the use of any active list, the connected resource MUST send an empty <active/> element 
@@ -195,7 +195,7 @@ namespace agsXMPP.protocol.iq.privacy
             pIq.Type = agsXMPP.protocol.client.IqType.set;
             pIq.Query.Active = new Active();
 
-            SendStanza(pIq, cb, cbArg);
+            SendStanza(pIq, cb);
         }
 
         /// <summary>
@@ -204,7 +204,7 @@ namespace agsXMPP.protocol.iq.privacy
         /// <param name="name"></param>
         public void ChangeActiveList(string name)
         {
-            ChangeActiveList(name, null, null);
+            ChangeActiveList(name, null);
         }
 
         /// <summary>
@@ -213,7 +213,7 @@ namespace agsXMPP.protocol.iq.privacy
         /// <param name="name"></param>
         /// <param name="cb">Callback for the server result</param>
         /// <param name="cbArg">Callback arguments for the result when needed</param>
-        public void ChangeActiveList(string name, IqCB cb, object cbArg)
+        public void ChangeActiveList(string name, IqHandler cb)
         {
             /*
                 Example: Client requests change of active list:
@@ -251,7 +251,7 @@ namespace agsXMPP.protocol.iq.privacy
             pIq.Type = agsXMPP.protocol.client.IqType.set;
             pIq.Query.Active = new Active(name);
 
-            SendStanza(pIq, cb, cbArg);
+            SendStanza(pIq, cb);
         }
 
         /// <summary>
@@ -260,7 +260,7 @@ namespace agsXMPP.protocol.iq.privacy
         /// <param name="name">name of the new default list</param>
         public void ChangeDefaultList(string name)
         {
-            ChangeDefaultList(name, null, null);
+            ChangeDefaultList(name, null);
         }
 
         /// <summary>
@@ -269,14 +269,14 @@ namespace agsXMPP.protocol.iq.privacy
         /// <param name="name">name of the new default list</param>
         /// <param name="cb">Callback for the server result</param>
         /// <param name="cbArg">Callback arguments for the result when needed</param>
-        public void ChangeDefaultList(string name, IqCB cb, object cbArg)
+        public void ChangeDefaultList(string name, IqHandler cb)
         {
             PrivacyIq pIq = new PrivacyIq();
 
             pIq.Type = agsXMPP.protocol.client.IqType.set;
             pIq.Query.Default = new Default(name);
 
-            SendStanza(pIq, cb, cbArg);
+            SendStanza(pIq, cb);
         }
 
         /// <summary>
@@ -284,7 +284,7 @@ namespace agsXMPP.protocol.iq.privacy
         /// </summary>
         public void DeclineDefaultList()
         {
-            DeclineDefaultList(null, null);
+            DeclineDefaultList(null);
         }
 
         /// <summary>
@@ -292,14 +292,14 @@ namespace agsXMPP.protocol.iq.privacy
         /// </summary>
         /// <param name="cb">Callback for the server result</param>
         /// <param name="cbArg">Callback arguments for the result when needed</param>
-        public void DeclineDefaultList(IqCB cb, object cbArg)
+        public void DeclineDefaultList(IqHandler cb)
         {
             PrivacyIq pIq = new PrivacyIq();
 
             pIq.Type = agsXMPP.protocol.client.IqType.set;
             pIq.Query.Default = new Default();
 
-            SendStanza(pIq, cb, cbArg);
+            SendStanza(pIq, cb);
         }
 
       
@@ -315,7 +315,7 @@ namespace agsXMPP.protocol.iq.privacy
         /// <param name="rules">rules of this list</param>
         public void UpdateList(string name, Item[] rules)
         {
-            UpdateList(name, rules, null, null);
+            UpdateList(name, rules, null);
         }
 
         /// <summary>
@@ -329,7 +329,7 @@ namespace agsXMPP.protocol.iq.privacy
         /// <param name="rules">rules of this list</param>
         /// <param name="cb">Callback for the server result</param>
         /// <param name="cbArg">Callback arguments for the result when needed</param>
-        public void UpdateList(string name, Item[] rules, IqCB cb, object cbArg)
+        public void UpdateList(string name, Item[] rules, IqHandler cb)
         {
             PrivacyIq pIq = new PrivacyIq();
             pIq.Type = agsXMPP.protocol.client.IqType.set;
@@ -340,7 +340,7 @@ namespace agsXMPP.protocol.iq.privacy
             // add the list to the query
             pIq.Query.AddList(list);
 
-            SendStanza(pIq, cb, cbArg);
+            SendStanza(pIq, cb);
         }
 
         /// <summary>
@@ -350,7 +350,7 @@ namespace agsXMPP.protocol.iq.privacy
         /// <param name="rules"></param>
         public void AddList(string name, Item[] rules)
         {
-            AddList(name, rules, null, null);
+            AddList(name, rules, null);
         }
 
         /// <summary>
@@ -360,9 +360,9 @@ namespace agsXMPP.protocol.iq.privacy
         /// <param name="rules"></param>
         ///// <param name="cb">Callback for the server result</param>
         /// <param name="cbArg">Callback arguments for the result when needed</param>
-        public void AddList(string name, Item[] rules, IqCB cb, object cbArg)
+        public void AddList(string name, Item[] rules, IqHandler cb)
         {
-            UpdateList(name, rules, cb, cbArg);
+            UpdateList(name, rules, cb);
         }
 
         /// <summary>
@@ -371,12 +371,12 @@ namespace agsXMPP.protocol.iq.privacy
         /// <param name="pIq"></param>
         /// <param name="cb"></param>
         /// <param name="cbArg"></param>
-        private void SendStanza(PrivacyIq pIq, IqCB cb, object cbArg)
+        private void SendStanza(PrivacyIq pIq, IqHandler cb)
         {
             if (cb == null)
                 m_connection.Send(pIq);
             else
-                m_connection.IqGrabber.SendIq(pIq, cb, cbArg);
+                m_connection.IqGrabber.SendIq(pIq, cb);
         }
         
 

--- a/agsxmpp/protocol/x/muc/MucManager.cs
+++ b/agsxmpp/protocol/x/muc/MucManager.cs
@@ -334,17 +334,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room"></param>
         public void AcceptDefaultConfiguration(Jid room)
         {
-            AcceptDefaultConfiguration(room, null, null);
-        }
-
-        /// <summary>
-        /// create an "instant room". This means you accept the default configuration and dont want to configure the room.
-        /// </summary>
-        /// <param name="room"></param>
-        /// <param name="cb"></param>
-        public void AcceptDefaultConfiguration(Jid room, IqCB cb)
-        {
-            AcceptDefaultConfiguration(room, cb, null);
+            AcceptDefaultConfiguration(room, null);
         }
 
         /// <summary>
@@ -353,7 +343,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room"></param>
         /// <param name="cb"></param>
         /// <param name="cbArgs"></param>
-        public void AcceptDefaultConfiguration(Jid room, IqCB cb, object cbArgs)
+        public void AcceptDefaultConfiguration(Jid room, IqHandler cb)
         {
             OwnerIq oIq = new agsXMPP.protocol.x.muc.iq.owner.OwnerIq(IqType.set, room);
             oIq.Query.AddChild(new Data(XDataFormType.submit));
@@ -361,7 +351,7 @@ namespace agsXMPP.protocol.x.muc
             if (cb == null)
                 m_connection.Send(oIq);
             else
-                m_connection.IqGrabber.SendIq(oIq, cb, cbArgs);
+                m_connection.IqGrabber.SendIq(oIq, cb);
         }
         
         /*
@@ -383,19 +373,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room"></param>
         public void RequestConfigurationForm(Jid room)
         {
-            RequestConfigurationForm(room, null, null);
-        }
-
-        /// <summary>
-        /// Request the configuration form of a chatroom.
-        /// You can request the from when creating a new room. or at any time later if you want to change the room configuration.
-        /// Only room owners can request this from. Otherwise the service must return a 403 forbidden error
-        /// </summary>
-        /// <param name="room"></param>
-        /// <param name="cb"></param>
-        public void RequestConfigurationForm(Jid room, IqCB cb)
-        {
-            RequestConfigurationForm(room, cb, null);
+            RequestConfigurationForm(room, null);
         }
 
         /// <summary>
@@ -406,11 +384,11 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room"></param>
         /// <param name="cb"></param>
         /// <param name="cbArgs"></param>
-        public void RequestConfigurationForm(Jid room, IqCB cb, object cbArgs)
+        public void RequestConfigurationForm(Jid room, IqHandler cb)
         {
             OwnerIq oIq = new agsXMPP.protocol.x.muc.iq.owner.OwnerIq(IqType.get, room);          
 
-            m_connection.IqGrabber.SendIq(oIq, cb, cbArgs);
+            m_connection.IqGrabber.SendIq(oIq, cb);
         }
 
         /*
@@ -436,7 +414,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="nickname">Nickname od the occupant to kick</param>
         public void KickOccupant(Jid room, string nickname)
         {
-            KickOccupant(room, nickname, null, null, null);
+            KickOccupant(room, nickname, null, null);
         }
 
         /// <summary>
@@ -450,23 +428,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason">A optional reason why you kick this occupant</param>
         public void KickOccupant(Jid room, string nickname, string reason)
         {
-            KickOccupant(room, nickname, reason, null, null);
-        }
-
-
-        /// <summary>
-        /// Kick a occupant
-        /// A moderator has permissions kick a visitor or participant from a room.
-        /// The kick is normally performed based on the occupant's room nickname (though it MAY be based on the full JID)
-        /// and is completed by setting the role of a participant or visitor to a value of "none".
-        /// </summary>
-        /// <param name="room">Jid of the room to which this iq is sent</param>
-        /// <param name="nickname">Nickname od the occupant to kick</param>
-        /// <param name="reason">A optional reason why you kick this occupant</param>
-        /// <param name="cb">Callback which is invoked with the result to this iq</param>        
-        public void KickOccupant(Jid room, string nickname, string reason, IqCB cb)
-        {
-            KickOccupant(room, nickname, reason, cb, null);
+            KickOccupant(room, nickname, reason, null);
         }
 
         /// <summary>
@@ -480,9 +442,9 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason">A optional reason why you kick this occupant</param>
         /// <param name="cb">Callback which is invoked with the result to this iq</param>
         /// <param name="cbArg">Callback which is invoked with the result to this iq</param>
-        public void KickOccupant(Jid room, string nickname, string reason, IqCB cb, object cbArg)
+        public void KickOccupant(Jid room, string nickname, string reason, IqHandler cb)
         {
-            ChangeRole(Role.none, room, nickname, reason, cb, cbArg);            
+            ChangeRole(Role.none, room, nickname, reason, cb);            
         }
 
         /*
@@ -508,7 +470,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="nickname"></param>
         public void GrantVoice(Jid room, string nickname)
         {
-            GrantVoice(room, nickname, null, null, null);
+            GrantVoice(room, nickname, null, null);
         }
 
         /// <summary>
@@ -519,19 +481,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason"></param>
         public void GrantVoice(Jid room, string nickname, string reason)
         {
-            GrantVoice(room, nickname, reason, null, null);
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="room">Jid of the room to which this iq is sent</param>
-        /// <param name="nickname"></param>
-        /// <param name="reason"></param>
-        /// <param name="cb"></param>        
-        public void GrantVoice(Jid room, string nickname, string reason, IqCB cb)
-        {
-            GrantVoice(room, nickname, reason, cb, null);
+            GrantVoice(room, nickname, reason, null);
         }
 
         /// <summary>
@@ -542,9 +492,9 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason"></param>
         /// <param name="cb"></param>
         /// <param name="cbArg"></param>
-        public void GrantVoice(Jid room, string nickname, string reason, IqCB cb, object cbArg)
+        public void GrantVoice(Jid room, string nickname, string reason, IqHandler cb)
         {
-            ChangeRole(Role.participant, room, nickname, reason, cb, cbArg);            
+            ChangeRole(Role.participant, room, nickname, reason, cb);            
         }
 
         /*
@@ -569,7 +519,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="nickname"></param>
         public void RevokeVoice(Jid room, string nickname)
         {
-            RevokeVoice(room, nickname, null, null, null);
+            RevokeVoice(room, nickname, null, null);
         }
 
         /// <summary>
@@ -581,20 +531,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason"></param>
         public void RevokeVoice(Jid room, string nickname, string reason)
         {
-            RevokeVoice(room, nickname, reason, null, null);
-        }
-
-        /// <summary>
-        /// In a moderated room, a moderator may want to revoke a participant's privileges to speak.
-        /// The moderator can revoke voice from a participant by changing the participant's role to "visitor":
-        /// </summary>
-        /// <param name="room">Jid of the room to which this iq is sent</param>
-        /// <param name="nickname"></param>
-        /// <param name="reason"></param>
-        /// <param name="cb"></param>
-        public void RevokeVoice(Jid room, string nickname, string reason, IqCB cb)
-        {
-            RevokeVoice(room, nickname, reason, cb, null);
+            RevokeVoice(room, nickname, reason, null);
         }
 
         /// <summary>
@@ -606,9 +543,9 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason"></param>
         /// <param name="cb"></param>
         /// <param name="cbArg"></param>
-        public void RevokeVoice(Jid room, string nickname, string reason, IqCB cb, object cbArg)
+        public void RevokeVoice(Jid room, string nickname, string reason, IqHandler cb)
         {
-            ChangeRole(Role.visitor, room, nickname, reason, cb, cbArg);
+            ChangeRole(Role.visitor, room, nickname, reason, cb);
         }        
 
         /*
@@ -641,27 +578,8 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room">Jid of the room to which this iq is sent</param>
         public void RequestVoiceList(Jid room)
         {
-            RequestVoiceList(room, null, null);
+            RequestVoiceList(room, null);
         }        
-        
-        /// <summary>
-        /// A moderator in a moderated room may want to modify the voice list. 
-        /// To do so, the moderator first requests the voice list by querying the room for all occupants 
-        /// with a role of 'participant'.
-        /// The service MUST then return the voice list to the moderator; each item MUST include 
-        /// the 'nick' and 'role' attributes and SHOULD include the 'affiliation' and 'jid' attributes.
-        /// The moderator MAY then modify the voice list. In order to do so, the moderator MUST send the 
-        /// changed items (i.e., only the "delta") back to the service; each item MUST include 
-        /// the 'nick' attribute and 'role' attribute (normally set to a value of "participant" or "visitor") 
-        /// but SHOULD NOT include the 'jid' attribute and MUST NOT include the 'affiliation' attribute 
-        /// (which is used to manage affiliations such as owner rather than the participant role),        
-        /// </summary>
-        /// <param name="room">Jid of the room to which this iq is sent</param>
-        /// <param name="cb"></param>
-        public void RequestVoiceList(Jid room, IqCB cb)
-        {
-            RequestVoiceList(room, cb, null);
-        }
 
         /// <summary>
         /// A moderator in a moderated room may want to modify the voice list. 
@@ -678,9 +596,9 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room">Jid of the room to which this iq is sent</param>
         /// <param name="cb"></param>
         /// <param name="cbArg"></param>
-        public void RequestVoiceList(Jid room, IqCB cb, object cbArg)
+        public void RequestVoiceList(Jid room, IqHandler cb)
         {
-            RequestList(Role.participant, room, cb, cbArg);            
+            RequestList(Role.participant, room, cb);            
         }
 
         /*
@@ -706,7 +624,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="user"></param>
         public void BanUser(Jid room, Jid user)
         {
-            BanUser(room, user, null, null, null);
+            BanUser(room, user, null, null);
         }
 
         /// <summary>
@@ -717,20 +635,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason"></param>
         public void BanUser(Jid room, Jid user, string reason)
         {
-            BanUser(room, user, reason, null, null);
-        }
-
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="room"></param>
-        /// <param name="user"></param>
-        /// <param name="reason"></param>
-        /// <param name="cb"></param>
-        public void BanUser(Jid room, Jid user, string reason, IqCB cb)
-        {
-            BanUser(room, user, reason, cb, null);
+            BanUser(room, user, reason, null);
         }
 
         /// <summary>
@@ -741,9 +646,9 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason"></param>
         /// <param name="cb"></param>
         /// <param name="cbArg"></param>
-        public void BanUser(Jid room, Jid user, string reason, IqCB cb, object cbArg)
+        public void BanUser(Jid room, Jid user, string reason, IqHandler cb)
         {
-            ChangeAffiliation(Affiliation.outcast, room, user, null, reason, cb, cbArg);            
+            ChangeAffiliation(Affiliation.outcast, room, user, null, reason, cb);            
         }
 
         /*
@@ -774,24 +679,8 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room"></param>
         public void RequestBanList(Jid room)
         {
-            RequestBanList(room, null, null);
+            RequestBanList(room, null);
         }        
-
-        /// <summary>
-        /// A room admin may want to modify the ban list. 
-        /// <remarks>
-        /// Note: The ban list is always based on a user's bare JID, 
-        /// although a nick (perhaps the last room nickname associated with that JID) MAY be included for convenience. 
-        /// To modify the list of banned JIDs, the admin first requests the ban list by querying the room for all 
-        /// users with an affiliation of 'outcast'.
-        /// </remarks>
-        /// </summary>
-        /// <param name="room"></param>        
-        /// <param name="cb"></param>
-        public void RequestBanList(Jid room, IqCB cb)
-        {
-            RequestBanList(room, cb, null);
-        }
 
         /// <summary>
         /// A room admin may want to modify the ban list. 
@@ -805,9 +694,9 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room"></param>
         /// <param name="cb"></param>
         /// <param name="cbArg"></param>
-        public void RequestBanList(Jid room, IqCB cb, object cbArg)
+        public void RequestBanList(Jid room, IqHandler cb)
         {
-            RequestList(Affiliation.outcast, room, cb, cbArg);
+            RequestList(Affiliation.outcast, room, cb);
         }
 
 
@@ -835,19 +724,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="user"></param>
         public void GrantAdminPrivileges(Jid room, Jid user)
         {
-            GrantAdminPrivileges(room, user, null, null);
-        }
-
-        /// <summary>
-        /// Grant administrative privileges to a member or unaffiliated user.
-        /// This could be done by an room owner
-        /// </summary>
-        /// <param name="room"></param>
-        /// <param name="user"></param>
-        /// <param name="cb"></param>
-        public void GrantAdminPrivileges(Jid room, Jid user, IqCB cb)
-        {
-            GrantAdminPrivileges(room, user, cb, null);
+            GrantAdminPrivileges(room, user, null);
         }
 
         /// <summary>
@@ -858,9 +735,9 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="user"></param>
         /// <param name="cb"></param>
         /// <param name="cbArg"></param>
-        public void GrantAdminPrivileges(Jid room, Jid user, IqCB cb, object cbArg)
+        public void GrantAdminPrivileges(Jid room, Jid user, IqHandler cb)
         {
-            ChangeAffiliation(Affiliation.admin, room, user, cb, cbArg);
+            ChangeAffiliation(Affiliation.admin, room, user, cb);
         }
 
 
@@ -895,7 +772,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="user"></param>
         public void GrantMembership(Jid room, Jid user)
         {
-            GrantMembership(room, user, null, null, null);
+            GrantMembership(room, user, null, null);
         }
 
         /// <summary>
@@ -910,23 +787,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason"></param>
         public void GrantMembership(Jid room, Jid user, string reason)
         {
-            GrantMembership(room, user, reason, null, null);
-        }
-
-        /// <summary>
-        /// An admin can grant membership to a user; 
-        /// this is done by changing the user's affiliation to "member" 
-        /// (normally based on nick if the user is in the room, or on bare JID if not; 
-        /// in either case, if the nick is provided, that nick becomes the user's default nick in the room
-        /// if that functionality is supported by the implementation)
-        /// </summary>
-        /// <param name="room"></param>
-        /// <param name="user"></param>
-        /// <param name="reason"></param>
-        /// <param name="cb"></param>
-        public void GrantMembership(Jid room, Jid user, string reason, IqCB cb)
-        {
-            GrantMembership(room, user, reason, cb, null);
+            GrantMembership(room, user, reason, null);
         }
 
         /// <summary>
@@ -941,9 +802,9 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason"></param>
         /// <param name="cb"></param>
         /// <param name="cbArg"></param>
-        public void GrantMembership(Jid room, Jid user, string reason, IqCB cb, object cbArg)
+        public void GrantMembership(Jid room, Jid user, string reason, IqHandler cb)
         {
-            ChangeAffiliation(Affiliation.member, room, user, null, reason, cb, cbArg);
+            ChangeAffiliation(Affiliation.member, room, user, null, reason, cb);
         }
 
         /// <summary>
@@ -957,7 +818,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="nickname"></param>
         public void GrantMembership(Jid room, string nickname)
         {
-            GrantMembership(room, nickname, null, null, null);
+            GrantMembership(room, nickname, null, null);
         }
 
         /// <summary>
@@ -972,23 +833,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason"></param>
         public void GrantMembership(Jid room, string nickname, string reason)
         {
-            GrantMembership(room, nickname, reason, null, null);
-        }
-
-        /// <summary>
-        /// An admin can grant membership to a user; 
-        /// this is done by changing the user's affiliation to "member" 
-        /// (normally based on nick if the user is in the room, or on bare JID if not; 
-        /// in either case, if the nick is provided, that nick becomes the user's default nick in the room
-        /// if that functionality is supported by the implementation)
-        /// </summary>
-        /// <param name="room"></param>
-        /// <param name="nickname"></param>
-        /// <param name="reason"></param>
-        /// <param name="cb"></param>
-        public void GrantMembership(Jid room, string nickname, string reason, IqCB cb)
-        {
-            GrantMembership(room, nickname, reason, cb, null);
+            GrantMembership(room, nickname, reason, null);
         }
 
         /// <summary>
@@ -1003,9 +848,9 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason"></param>
         /// <param name="cb"></param>
         /// <param name="cbArg"></param>
-        public void GrantMembership(Jid room, string nickname, string reason, IqCB cb, object cbArg)
+        public void GrantMembership(Jid room, string nickname, string reason, IqHandler cb)
         {
-            ChangeAffiliation(Affiliation.member, room, nickname, reason, cb, cbArg);
+            ChangeAffiliation(Affiliation.member, room, nickname, reason, cb);
         }
 
 
@@ -1039,21 +884,10 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room"></param>
         /// <param name="user"></param>
         /// <param name="cb"></param>
-        public void GrantOwnershipPrivileges(Jid room, Jid user, IqCB cb)
-        {
-            ChangeAffiliation(Affiliation.owner, room, user, cb, null);
-        }
-
-        /// <summary>
-        /// If allowed by an implementation, an owner MAY grant ownership privileges to another user.        
-        /// </summary>
-        /// <param name="room"></param>
-        /// <param name="user"></param>
-        /// <param name="cb"></param>
         /// <param name="cbArg"></param>
-        public void GrantOwnershipPrivileges(Jid room, Jid user, IqCB cb, object cbArg)
+        public void GrantOwnershipPrivileges(Jid room, Jid user, IqHandler cb)
         {
-            ChangeAffiliation(Affiliation.owner, room, user, cb, cbArg);
+            ChangeAffiliation(Affiliation.owner, room, user, cb);
         }
 
         /*
@@ -1094,20 +928,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason"></param>
         public void RevokeMembership(Jid room, string nickname, string reason)
         {
-            RevokeMembership(room, nickname, reason, null, null);
-        }
-
-        /// <summary>
-        /// An admin may want to revoke a user's membership
-        /// this is done by changing the user's affiliation to "none"
-        /// </summary>
-        /// <param name="room"></param>
-        /// <param name="nickname"></param>
-        /// <param name="reason"></param>
-        /// <param name="cb"></param>
-        public void RevokeMembership(Jid room, string nickname, string reason, IqCB cb)
-        {
-            RevokeMembership(room, nickname, reason, cb, null);
+            RevokeMembership(room, nickname, reason, null);
         }
 
         /// <summary>
@@ -1119,9 +940,9 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason"></param>
         /// <param name="cb"></param>
         /// <param name="cbArg"></param>
-        public void RevokeMembership(Jid room, string nickname, string reason, IqCB cb, object cbArg)
+        public void RevokeMembership(Jid room, string nickname, string reason, IqHandler cb)
         {
-            ChangeAffiliation(Affiliation.none, room, nickname, reason, cb, cbArg);  
+            ChangeAffiliation(Affiliation.none, room, nickname, reason, cb);  
         }
 
 
@@ -1150,17 +971,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room"></param>
         public void RequestAdminList(Jid room)
         {
-            RequestAdminList(room, null, null);
-        }
-
-        /// <summary>
-        /// Request the list of admins. This could be done by the room owner
-        /// </summary>
-        /// <param name="room"></param>
-        /// <param name="cb"></param>
-        public void RequestAdminList(Jid room, IqCB cb)
-        {
-            RequestAdminList(room, cb, null);
+            RequestAdminList(room, null);
         }
 
         /// <summary>
@@ -1169,9 +980,9 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room"></param>
         /// <param name="cb"></param>
         /// <param name="cbArg"></param>
-        public void RequestAdminList(Jid room, IqCB cb, object cbArg)
+        public void RequestAdminList(Jid room, IqHandler cb)
         {
-            RequestList(Affiliation.admin, room, cb, cbArg);
+            RequestList(Affiliation.admin, room, cb);
         }
 
         /*
@@ -1197,17 +1008,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room"></param>
         public void RequestOwnerList(Jid room)
         {
-            RequestOwnerList(room, null, null);
-        }
-
-        /// <summary>
-        /// Request the owner list of a room
-        /// </summary>
-        /// <param name="room"></param>
-        /// <param name="cb"></param>
-        public void RequestOwnerList(Jid room, IqCB cb)
-        {
-            RequestOwnerList(room, cb, null);
+            RequestOwnerList(room, null);
         }
 
         /// <summary>
@@ -1216,9 +1017,9 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room"></param>
         /// <param name="cb"></param>
         /// <param name="cbArg"></param>
-        public void RequestOwnerList(Jid room, IqCB cb, object cbArg)
+        public void RequestOwnerList(Jid room, IqHandler cb)
         {
-            RequestList(Affiliation.owner, room, cb, cbArg);
+            RequestList(Affiliation.owner, room, cb);
         }
 
         /*
@@ -1248,24 +1049,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room"></param>
         public void RequestMemberList(Jid room)
         {
-            RequestMemberList(room, null, null);
-        }
-
-        /// <summary>
-        /// In the context of a members-only room, the member list is essentially a "whitelist" of people 
-        /// who are allowed to enter the room. Anyone who is not a member is effectively banned from entering the room, 
-        /// even if their affiliation is not "outcast".
-        /// In the context of an open room, the member list is simply a list of users (bare JID and reserved nick) 
-        /// who are registered with the room. Such users may appear in a room roster, have their room nickname reserved, 
-        /// be returned in search results or FAQ queries, and the like.
-        /// It is RECOMMENDED that only room admins have the privilege to modify the member list in members-only rooms. 
-        /// To do so, the admin first requests the member list by querying the room for all users with an affiliation of "member"
-        /// </summary>
-        /// <param name="room"></param>
-        /// <param name="cb"></param>
-        public void RequestMemberList(Jid room, IqCB cb)
-        {
-            RequestMemberList(room, cb, null);
+            RequestMemberList(room, null);
         }
 
         /// <summary>
@@ -1281,9 +1065,9 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room"></param>
         /// <param name="cb"></param>
         /// <param name="cbArg"></param>
-        public void RequestMemberList(Jid room, IqCB cb, object cbArg)
+        public void RequestMemberList(Jid room, IqHandler cb)
         {
-            RequestList(Affiliation.member, room, cb, cbArg);            
+            RequestList(Affiliation.member, room, cb);
         }
 
         /*
@@ -1313,7 +1097,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="nickname"></param>
         public void GrantModeratorPrivileges(Jid room, string nickname)
         {
-            GrantModeratorPrivileges(room, nickname, null, null, null);
+            GrantModeratorPrivileges(room, nickname, null, null);
         }
 
         /// <summary>
@@ -1325,20 +1109,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason"></param>
         public void GrantModeratorPrivileges(Jid room, string nickname, string reason)
         {
-            GrantModeratorPrivileges(room, nickname, reason, null, null);
-        }
-
-        /// <summary>
-        /// An admin may want to grant moderator privileges to a participant or visitor
-        /// this is done by changing the user's role to "moderator"
-        /// </summary>
-        /// <param name="room"></param>
-        /// <param name="nickname"></param>
-        /// <param name="reason"></param>
-        /// <param name="cb"></param>
-        public void GrantModeratorPrivileges(Jid room, string nickname, string reason, IqCB cb)
-        {
-            GrantModeratorPrivileges(room, nickname, reason, cb, null);
+            GrantModeratorPrivileges(room, nickname, reason, null);
         }
 
         /// <summary>
@@ -1350,9 +1121,9 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="reason"></param>
         /// <param name="cb"></param>
         /// <param name="cbArg"></param>
-        public void GrantModeratorPrivileges(Jid room, string nickname, string reason, IqCB cb, object cbArg)
+        public void GrantModeratorPrivileges(Jid room, string nickname, string reason, IqHandler cb)
         {
-            ChangeRole(Role.moderator, room, nickname, reason, cb, cbArg);
+            ChangeRole(Role.moderator, room, nickname, reason, cb);
         }
         
         /*
@@ -1375,22 +1146,17 @@ namespace agsXMPP.protocol.x.muc
 
         public void RevokeModerator(Jid room, string nickname)
         {
-            RevokeModerator(room, nickname, null, null, null);
+            RevokeModerator(room, nickname, null, null);
         }
 
         public void RevokeModerator(Jid room, string nickname, string reason)
         {
-            RevokeModerator(room, nickname, reason, null, null);
+            RevokeModerator(room, nickname, reason, null);
         }
 
-        public void RevokeModerator(Jid room, string nickname, string reason, IqCB cb)
+        public void RevokeModerator(Jid room, string nickname, string reason, IqHandler cb)
         {
-            RevokeModerator(room, nickname, reason, cb, null);
-        }
-
-        public void RevokeModerator(Jid room, string nickname, string reason, IqCB cb, object cbArg)
-        {
-            ChangeRole(Role.participant, room, nickname, reason, cb, cbArg);
+            ChangeRole(Role.participant, room, nickname, reason, cb);
         }
 
         /*
@@ -1417,17 +1183,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room">The room.</param>
         public void RequestModeratorList(Jid room)
         {
-            RequestModeratorList(room, null, null);
-        }
-
-        /// <summary>
-        /// Requests the moderator list.
-        /// </summary>
-        /// <param name="room">The room.</param>
-        /// <param name="cb">The cb.</param>
-        public void RequestModeratorList(Jid room, IqCB cb)
-        {
-            RequestModeratorList(room, cb, null);
+            RequestModeratorList(room, null);
         }
 
         /// <summary>
@@ -1436,13 +1192,13 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room">The room.</param>
         /// <param name="cb">The cb.</param>
         /// <param name="cbArg">The cb arg.</param>
-        public void RequestModeratorList(Jid room, IqCB cb, object cbArg)
+        public void RequestModeratorList(Jid room, IqHandler cb)
         {
-            RequestList(Role.moderator, room, cb, cbArg);
+            RequestList(Role.moderator, room, cb);
         }
 
 
-        public void RequestList(Affiliation affiliation, Jid room, IqCB cb, object cbArg)
+        public void RequestList(Affiliation affiliation, Jid room, IqHandler cb)
         {
             AdminIq aIq = new AdminIq();
             aIq.To = room;
@@ -1453,10 +1209,10 @@ namespace agsXMPP.protocol.x.muc
             if (cb == null)
                 m_connection.Send(aIq);
             else
-                m_connection.IqGrabber.SendIq(aIq, cb, cbArg);
+                m_connection.IqGrabber.SendIq(aIq, cb);
         }
 
-        public void RequestList(Role role, Jid room, IqCB cb, object cbArg)
+        public void RequestList(Role role, Jid room, IqHandler cb)
         {
             AdminIq aIq = new AdminIq();
             aIq.To = room;
@@ -1467,7 +1223,7 @@ namespace agsXMPP.protocol.x.muc
             if (cb == null)
                 m_connection.Send(aIq);
             else
-                m_connection.IqGrabber.SendIq(aIq, cb, cbArg);
+                m_connection.IqGrabber.SendIq(aIq, cb);
         }
 
         #region << Create Reserved Room >>
@@ -1479,21 +1235,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room">Jid of the room to create</param>
         public void CreateReservedRoom(Jid room)
         {
-            CreateReservedRoom(room, null, null);
-        }
-
-        /// <summary>
-        /// <para>
-        /// Creates a reserved room. The MUC server replies to this request either with an error if the room already exists 
-        /// or another error occured. Or with the configuration for, for the reserved room which you have submit in the
-        /// second step.
-        /// </para>        
-        /// </summary>
-        /// <param name="room">Jid of the room to create</param>
-        /// <param name="cb">callback for the response</param>
-        public void CreateReservedRoom(Jid room, IqCB cb)
-        {
-            CreateReservedRoom(room, cb, null);
+            CreateReservedRoom(room, null);
         }
 
         /// <summary>
@@ -1506,7 +1248,7 @@ namespace agsXMPP.protocol.x.muc
         /// <param name="room">Jid of the room to create</param>
         /// <param name="cb">callback for the response</param>
         /// <param name="cbArg">optional callback arguments</param>
-        public void CreateReservedRoom(Jid room, IqCB cb, object cbArg)
+        public void CreateReservedRoom(Jid room, IqHandler cb)
         {
             /*
             <iq from='crone1@shakespeare.lit/desktop'
@@ -1524,7 +1266,7 @@ namespace agsXMPP.protocol.x.muc
             if (cb == null)
                 m_connection.Send(iq);
             else
-                m_connection.IqGrabber.SendIq(iq, cb, cbArg);
+                m_connection.IqGrabber.SendIq(iq, cb);
         }
         #endregion       
 
@@ -1532,45 +1274,30 @@ namespace agsXMPP.protocol.x.muc
         #region << Destroy Room >>
         public void DestroyRoom(Jid room, Jid altVenue)
         {
-            DestroyRoom(room, altVenue, null, null, null);
+            DestroyRoom(room, altVenue, null, null);
         }
 
-        public void DestroyRoom(Jid room, Jid altVenue, IqCB cb)
+        public void DestroyRoom(Jid room, Jid altVenue, IqHandler cb)
         {
-            DestroyRoom(room, altVenue, null, cb, null);
-        }
-
-        public void DestroyRoom(Jid room, Jid altVenue, IqCB cb, object cbArg)
-        {
-            DestroyRoom(room, altVenue, null, cb, cbArg);
+            DestroyRoom(room, altVenue, null, cb);
         }
 
         public void DestroyRoom(Jid room, string reason)
         {
-            DestroyRoom(room, null, reason, null, null);
+            DestroyRoom(room, null, reason, null);
         }
 
-        public void DestroyRoom(Jid room, string reason, IqCB cb)
+        public void DestroyRoom(Jid room, string reason, IqHandler cb)
         {
-            DestroyRoom(room, null, reason, cb, null);
-        }
-
-        public void DestroyRoom(Jid room, string reason, IqCB cb, object cbArg)
-        {
-            DestroyRoom(room, null, reason, cb, cbArg);
+            DestroyRoom(room, null, reason, cb);
         }
 
         public void DestroyRoom(Jid room, Jid altVenue, string reason)
         {
-            DestroyRoom(room, altVenue, reason, null, null);
+            DestroyRoom(room, altVenue, reason, null);
         }
 
-        public void DestroyRoom(Jid room, Jid altVenue, string reason, IqCB cb)
-        {
-            DestroyRoom(room, altVenue, reason, cb, null);
-        }
-
-        public void DestroyRoom(Jid room, Jid altVenue, string reason, IqCB cb, object cbArg)       
+        public void DestroyRoom(Jid room, Jid altVenue, string reason, IqHandler cb)       
         {
             /*
              Example 177. Owner Submits Room Destruction Request
@@ -1604,22 +1331,17 @@ namespace agsXMPP.protocol.x.muc
             if (cb == null)
                 m_connection.Send(iq);
             else
-                m_connection.IqGrabber.SendIq(iq, cb, cbArg);
+                m_connection.IqGrabber.SendIq(iq, cb);
 
         }
         #endregion
 
         public void ModifyList(Jid room, agsXMPP.protocol.x.muc.iq.admin.Item[] items)
         {
-            ModifyList(room, items, null, null);
+            ModifyList(room, items, null);
         }
 
-        public void ModifyList(Jid room, agsXMPP.protocol.x.muc.iq.admin.Item[] items, IqCB cb)
-        {
-            ModifyList(room, items, cb, null);
-        }
-
-        public void ModifyList(Jid room, agsXMPP.protocol.x.muc.iq.admin.Item[] items, IqCB cb, object cbArg)
+        public void ModifyList(Jid room, agsXMPP.protocol.x.muc.iq.admin.Item[] items, IqHandler cb)
         {
             AdminIq aIq = new AdminIq();
             aIq.To = room;
@@ -1633,13 +1355,13 @@ namespace agsXMPP.protocol.x.muc
             if (cb == null)
                 m_connection.Send(aIq);
             else
-                m_connection.IqGrabber.SendIq(aIq, cb, cbArg);
+                m_connection.IqGrabber.SendIq(aIq, cb);
         }
 
 
         #region << private functions >>
 
-        private void ChangeRole(Role role, Jid room, string nickname, string reason, IqCB cb, object cbArg)
+        private void ChangeRole(Role role, Jid room, string nickname, string reason, IqHandler cb)
         {
             AdminIq aIq = new AdminIq();
             aIq.To = room;
@@ -1657,10 +1379,10 @@ namespace agsXMPP.protocol.x.muc
             if (cb == null)
                 m_connection.Send(aIq);
             else
-                m_connection.IqGrabber.SendIq(aIq, cb, cbArg);
+                m_connection.IqGrabber.SendIq(aIq, cb);
         }
         
-        private void ChangeAffiliation(Affiliation affiliation, Jid room, string nickname, string reason, IqCB cb, object cbArg)
+        private void ChangeAffiliation(Affiliation affiliation, Jid room, string nickname, string reason, IqHandler cb)
         {
             AdminIq aIq = new AdminIq();
             aIq.To = room;
@@ -1680,15 +1402,15 @@ namespace agsXMPP.protocol.x.muc
             if (cb == null)
                 m_connection.Send(aIq);
             else
-                m_connection.IqGrabber.SendIq(aIq, cb, cbArg);
+                m_connection.IqGrabber.SendIq(aIq, cb);
         }
 
-        private void ChangeAffiliation(Affiliation affiliation, Jid room, Jid user, IqCB cb, object cbArg)
+        private void ChangeAffiliation(Affiliation affiliation, Jid room, Jid user, IqHandler cb)
         {            
-            ChangeAffiliation(affiliation, room, user, null, null, cb, cbArg);
+            ChangeAffiliation(affiliation, room, user, null, null, cb);
         }
 
-        private void ChangeAffiliation(Affiliation affiliation, Jid room, Jid user, string nickname, string reason, IqCB cb, object cbArg)
+        private void ChangeAffiliation(Affiliation affiliation, Jid room, Jid user, string nickname, string reason, IqHandler cb)
         {
             var aIq = new AdminIq();
             aIq.To = room;
@@ -1711,7 +1433,7 @@ namespace agsXMPP.protocol.x.muc
             if (cb == null)
                 m_connection.Send(aIq);
             else
-                m_connection.IqGrabber.SendIq(aIq, cb, cbArg);      
+                m_connection.IqGrabber.SendIq(aIq, cb);      
         }
         #endregion
     }


### PR DESCRIPTION
it's a big one, but mostly removal of callbacks with object "parameters"

it was necessary to remove those callbacks and switch to EventArgs because we needed a "handled" boolean that signifies that some piece of code believes it properly handled a certain stanza.
whenever this does not happen, agsxmpp copies the stanza it received, turns it into an error and returns it to its source
