### PR TITLE
NullReferenceException happened when a server replied with an error to a...

### DIFF
--- a/agsxmpp/XmppClientConnection.cs
+++ b/agsxmpp/XmppClientConnection.cs
@@ -1212,6 +1212,10 @@ namespace agsXMPP
 			//		</iq>
 			// Recv:<iq id="mx_login" type="result"/> 
 			
+            if (iq.Error != null) {
+                FireOnAuthError(iq);
+                return;
+            }
 			iq.GenerateId();
 			iq.SwitchDirection();
 			iq.Type = IqType.set;


### PR DESCRIPTION
...n auth info request

this usually happens when you connect to a server that requires encryption but you have not enabled tls
