### PR TITLE
casting a null Jid to string caused NRE, casting null string to Jid retu...

### DIFF
--- a/agsxmpp/Jid.cs
+++ b/agsxmpp/Jid.cs
@@ -380,11 +380,17 @@ namespace agsXMPP
         #region << implicit operators >>
         static public implicit operator Jid(string value)
         {
+            if (value == null) {
+                return null;
+            }
             return new Jid(value);
         }
 
         static public implicit operator string(Jid jid)
         {
+            if (jid == null) {
+                return null;
+            }
             return jid.ToString();
         }
         #endregion


### PR DESCRIPTION
...rned a valid Jid object
